### PR TITLE
CSS: history 페이지 feature 인풋박스 투명하게 #36

### DIFF
--- a/frontend/src/components/historyFeatureTable.vue
+++ b/frontend/src/components/historyFeatureTable.vue
@@ -12,8 +12,8 @@
             <input
               :value="FEATURE_values[j + 6*i - 7]"
               type="text"
-              class="main-searchbox"
-              disabled
+              class="history-feature-value-box"
+              readonly
             />
           </td>
         </tr>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -52,6 +52,11 @@ td {
   width: 140px;
 }
 
+.history-feature-value-box {
+  border: 1px solid transparent;
+  outline: none;
+}
+
 #reset-button,
 #predict-button {
   width: 60px;
@@ -65,6 +70,7 @@ td {
   background-color: #001a41;
   color: #f8f9fa;
   border-color: #001a41;
+  cursor: pointer;
 }
 
 :root {


### PR DESCRIPTION
- history 페이지 feature 인풋박스 투명하게 하기