### PR TITLE
fix: 히스토리 페이지 9시간 전으로 표시

### DIFF
--- a/frontend/src/components/historyMainTable.vue
+++ b/frontend/src/components/historyMainTable.vue
@@ -72,6 +72,7 @@ export default {
     },
     formatDate(date_str) {
       let date_ = new Date(date_str);
+      date_.setHours(date_.getHours() - 9);
       return date_.toLocaleString('ko-KR');
     }
   },


### PR DESCRIPTION
- 히스토리 페이지 시각 한국시각으로 표시